### PR TITLE
fix: correct wasm-bindgen version check error message

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -26,7 +26,7 @@ const expectedWasmBindgenVersion = "0.2.80";
 if (crate.wasmBindgenVersion !== expectedWasmBindgenVersion) {
   throw new Error(
     `The crate '${crate.name}' must have a dependency on wasm-bindgen ` +
-      `${crate.wasmBindgenVersion} (found ` +
+      `${expectedWasmBindgenVersion} (found ` +
       `${crate.wasmBindgenVersion ?? "<WASM-BINDGEN NOT FOUND>"})`,
   );
 }


### PR DESCRIPTION
Error message was wrong:

```
error: Uncaught (in promise) Error: The crate 'eszip_wasm' must have a dependency on wasm-bindgen 0.2.79 (found 0.2.79)
  throw new Error(
        ^
    at https://deno.land/x/wasmbuild@0.1.1/main.ts:27:9
```