### PR TITLE
feat: add `isInstantiated` export

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -165,7 +165,7 @@ let lastLoadPromise;
  */
 export function instantiateWithInstance() {
   if (instanceWithExports != null) {
-    return instanceWithExports;
+    return Promise.resolve(instanceWithExports);
   }
   if (lastLoadPromise == null) {
     lastLoadPromise = (async () => {
@@ -185,6 +185,11 @@ export function instantiateWithInstance() {
     })();
   }
   return lastLoadPromise;
+}
+
+/** Gets if the Wasm module has been instantiated. */
+export function isInstantiated() {
+  return instanceWithExports != null;
 }
 
 async function instantiateModule() {

--- a/tests/lib/deno_test.generated.js
+++ b/tests/lib/deno_test.generated.js
@@ -130,7 +130,7 @@ let lastLoadPromise;
  */
 export function instantiateWithInstance() {
   if (instanceWithExports != null) {
-    return instanceWithExports;
+    return Promise.resolve(instanceWithExports);
   }
   if (lastLoadPromise == null) {
     lastLoadPromise = (async () => {
@@ -150,6 +150,11 @@ export function instantiateWithInstance() {
     })();
   }
   return lastLoadPromise;
+}
+
+/** Gets if the Wasm module has been instantiated. */
+export function isInstantiated() {
+  return instanceWithExports != null;
 }
 
 async function instantiateModule() {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,8 +1,11 @@
-import { greet, instantiate } from "./lib/deno_test.generated.js";
+import { greet, instantiate, isInstantiated } from "./lib/deno_test.generated.js";
 import { assertEquals } from "https://deno.land/std@0.142.0/testing/asserts.ts";
+
+assertEquals(isInstantiated(), false);
 
 Deno.test("test works export", async () => {
   await instantiate();
+  assertEquals(isInstantiated(), true);
   assertEquals(greet("Deno"), "Hello, Deno! Result: 3");
 });
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,4 +1,8 @@
-import { greet, instantiate, isInstantiated } from "./lib/deno_test.generated.js";
+import {
+  greet,
+  instantiate,
+  isInstantiated,
+} from "./lib/deno_test.generated.js";
 import { assertEquals } from "https://deno.land/std@0.142.0/testing/asserts.ts";
 
 assertEquals(isInstantiated(), false);


### PR DESCRIPTION
This will be useful for telling if a module has been instantiated yet.