### PR TITLE
feat: add `--js-ext <ext_no_period>`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 target/
+tests/lib_out_js_file

--- a/README.md
+++ b/README.md
@@ -42,16 +42,18 @@ greet("Deno");
 
 ### CLI Flags
 
-- `--check` - Checks to ensure the output is up to date.
-  - This is useful to run on the CI in order to ensure the wasmbuild output is
-    up to date.
 - `--debug` - Build without optimizations.
-- `--project <crate-name>` / `-p <crate-name>` - Specifies the crate to build
+- `--project <crate_name>` / `-p <crate_name>` - Specifies the crate to build
   when using a Cargo workspace.
-- `--out <dir-path>` - Specifies the output directory. Defaults to `./lib`
+- `--out <dir_path>` - Specifies the output directory. Defaults to `./lib`
+- `--out-js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS file.
+  Defaults to `js`.
 - `--all-features` - Build the crate with all features.
 - `--no-default-features` - Build the crate with no default features.
 - `--features` - Specify the features to create. Specify multiple features
   quoted and with spaces (ex. `--features "wasm serialization"`).
 - `--sync` - Generate a synchronous module that stores the Wasm module inline as
   base64 text.
+- `--check` - Checks to ensure the output is up to date.
+  - This is useful to run on the CI in order to ensure the wasmbuild output is
+    up to date.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ greet("Deno");
 - `--project <crate_name>` / `-p <crate_name>` - Specifies the crate to build
   when using a Cargo workspace.
 - `--out <dir_path>` - Specifies the output directory. Defaults to `./lib`
-- `--out-js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS file.
-  Defaults to `js`.
+- `--out-js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS
+  file. Defaults to `js`.
 - `--all-features` - Build the crate with all features.
 - `--no-default-features` - Build the crate with no default features.
 - `--features` - Specify the features to create. Specify multiple features

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ greet("Deno");
 - `--project <crate_name>` / `-p <crate_name>` - Specifies the crate to build
   when using a Cargo workspace.
 - `--out <dir_path>` - Specifies the output directory. Defaults to `./lib`
-- `--js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS
-  file. Defaults to `js`.
+- `--js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS file.
+  Defaults to `js`.
 - `--all-features` - Build the crate with all features.
 - `--no-default-features` - Build the crate with no default features.
 - `--features` - Specify the features to create. Specify multiple features

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ greet("Deno");
 - `--project <crate_name>` / `-p <crate_name>` - Specifies the crate to build
   when using a Cargo workspace.
 - `--out <dir_path>` - Specifies the output directory. Defaults to `./lib`
-- `--out-js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS
+- `--js-ext <ext_no_period>` - Extension to use for the wasm bindgen JS
   file. Defaults to `js`.
 - `--all-features` - Build the crate with all features.
 - `--no-default-features` - Build the crate with no default features.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,6 +11,10 @@
     "fmt": "deno fmt && cargo fmt",
     "build": "deno run -A --unstable ./main.ts -p wasmbuild",
     "build:lkg": "deno run -A --unstable https://deno.land/x/wasmbuild@0.5.0/main.ts -p wasmbuild",
-    "test": "cd tests && deno run --unstable -A ../main.ts -p deno_test && deno run --unstable -A ../main.ts -p deno_test --sync --out lib_sync && deno test -A && deno run --unstable -A ../main.ts -p deno_test --check"
+    "test": "cd tests && deno task test:main && deno task test:sync && deno task test:out-js-file && deno test -A && deno task test:check",
+    "test:main": "cd tests && deno run --unstable -A ../main.ts -p deno_test",
+    "test:sync": "deno task test:main --sync --out lib_sync",
+    "test:out-js-file": "rm -rf tests/lib_out_js_file && deno task test:main --out-js-ext mjs --out lib_out_js_file && cat tests/lib_out_js_file/deno_test.generated.mjs > /dev/null",
+    "test:check": "deno task test:main --check"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,10 +11,10 @@
     "fmt": "deno fmt && cargo fmt",
     "build": "deno run -A --unstable ./main.ts -p wasmbuild",
     "build:lkg": "deno run -A --unstable https://deno.land/x/wasmbuild@0.5.0/main.ts -p wasmbuild",
-    "test": "cd tests && deno task test:main && deno task test:sync && deno task test:out-js-file && deno test -A && deno task test:check",
+    "test": "cd tests && deno task test:main && deno task test:sync && deno task test:js-ext && deno test -A && deno task test:check",
     "test:main": "cd tests && deno run --unstable -A ../main.ts -p deno_test",
     "test:sync": "deno task test:main --sync --out lib_sync",
-    "test:out-js-file": "rm -rf tests/lib_out_js_file && deno task test:main --out-js-ext mjs --out lib_out_js_file && cat tests/lib_out_js_file/deno_test.generated.mjs > /dev/null",
+    "test:js-ext": "rm -rf tests/lib_out_js_file && deno task test:main --js-ext mjs --out lib_out_js_file && cat tests/lib_out_js_file/deno_test.generated.mjs > /dev/null",
     "test:check": "deno task test:main --check"
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -40,7 +40,7 @@ const isSync: boolean = flags.sync ?? false;
 const isCheck: boolean = flags.check ?? false;
 const outDir = flags.out ?? "./lib";
 const crate = workspace.getWasmCrate(specifiedCrateName);
-const bindingJsFileExt = flags["out-js-ext"] ?? `js`;
+const bindingJsFileExt = flags["js-ext"] ?? `js`;
 const bindingJsFileName = `${crate.libName}.generated.${bindingJsFileExt}`;
 const expectedWasmBindgenVersion = "0.2.81";
 

--- a/main.ts
+++ b/main.ts
@@ -40,6 +40,8 @@ const isSync: boolean = flags.sync ?? false;
 const isCheck: boolean = flags.check ?? false;
 const outDir = flags.out ?? "./lib";
 const crate = workspace.getWasmCrate(specifiedCrateName);
+const bindingJsFileExt = flags["out-js-ext"] ?? `js`;
+const bindingJsFileName = `${crate.libName}.generated.${bindingJsFileExt}`;
 const expectedWasmBindgenVersion = "0.2.81";
 
 if (crate.wasmBindgenVersion !== expectedWasmBindgenVersion) {
@@ -117,7 +119,7 @@ console.log(
   `${colors.bold(colors.green("Generating"))} lib JS bindings...`,
 );
 const wasmFileName = `${crate.libName}_bg.wasm`;
-const bindingJsPath = path.join(outDir, `${crate.libName}.generated.js`);
+const bindingJsPath = path.join(outDir, bindingJsFileName);
 const bindingJsText = await getBindingJsText();
 
 if (isCheck) {

--- a/manifest.ts
+++ b/manifest.ts
@@ -167,7 +167,6 @@ export class WasmCrate {
       })
     ) {
       if (entry.isFile) {
-        console.log(entry.path);
         paths.push(entry.path);
       }
     }


### PR DESCRIPTION
Will use this with deno_std because it needs to be an mjs file there for node compat.

This is a basic implementation and ideally also the snippets and local modules could be updated.