### PR TITLE
fix: --check should work with --sync across operating systems

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,6 +15,6 @@
     "test:main": "cd tests && deno run --unstable -A ../main.ts -p deno_test",
     "test:sync": "deno task test:main --sync --out lib_sync",
     "test:js-ext": "rm -rf tests/lib_out_js_file && deno task test:main --js-ext mjs --out lib_out_js_file && cat tests/lib_out_js_file/deno_test.generated.mjs > /dev/null",
-    "test:check": "deno task test:main --check"
+    "test:check": "deno task test:main --check && deno task test:sync --check"
   }
 }

--- a/lib/wasmbuild.generated.js
+++ b/lib/wasmbuild.generated.js
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // @generated file from build script, do not edit
 // deno-lint-ignore-file
-// 40786c94d923843cafc8b7f747eda57d10153b90
+// source-hash: 40786c94d923843cafc8b7f747eda57d10153b90
 let wasm;
 
 const cachedTextDecoder = new TextDecoder("utf-8", {

--- a/tests/lib/deno_test.generated.js
+++ b/tests/lib/deno_test.generated.js
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // @generated file from build script, do not edit
 // deno-lint-ignore-file
-// 30a5c71e9a72f3f3b278f8c0b1fc20945d9642c8
+// source-hash: 30a5c71e9a72f3f3b278f8c0b1fc20945d9642c8
 let wasm;
 import { add } from "./snippets/deno_test-0783d0dd1a7e0cd8/add.js";
 

--- a/tests/lib_sync/deno_test.generated.js
+++ b/tests/lib_sync/deno_test.generated.js
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // @generated file from build script, do not edit
 // deno-lint-ignore-file
-// 30a5c71e9a72f3f3b278f8c0b1fc20945d9642c8
+// source-hash: 30a5c71e9a72f3f3b278f8c0b1fc20945d9642c8
 let wasm;
 import { add } from "./snippets/deno_test-0783d0dd1a7e0cd8/add.js";
 


### PR DESCRIPTION
Using `--sync` will inline the wasm in the JS file, which will be different based on what operating system the user is on. To fix this, we need to only look at the hash.