### PR TITLE
fix: correct output order

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -166,6 +166,9 @@ async function checkOutputUpToDate() {
 async function writeOutput() {
   await writeSnippets();
 
+  console.log(`  write ${colors.yellow(bindingJsPath)}`);
+  await Deno.writeTextFile(bindingJsPath, bindingJsText);
+
   if (!isSync) {
     const wasmDest = path.join(outDir, wasmFileName);
     await Deno.writeFile(wasmDest, new Uint8Array(bindgenOutput.wasmBytes));
@@ -173,9 +176,6 @@ async function writeOutput() {
       await optimizeWasmFile(wasmDest);
     }
   }
-
-  console.log(`  write ${colors.yellow(bindingJsPath)}`);
-  await Deno.writeTextFile(bindingJsPath, bindingJsText);
 
   console.log(
     `${colors.bold(colors.green("Finished"))} ${crate.name} web assembly.`,

--- a/wasmopt.ts
+++ b/wasmopt.ts
@@ -17,9 +17,8 @@ const tag = "version_109";
 
 export async function runWasmOpt(filePath: string) {
   const binPath = await getWasmOptBinaryPath();
-  const optimizedPath = filePath + ".temp";
   const p = Deno.run({
-    cmd: [binPath, "-Oz", filePath, "-o", optimizedPath],
+    cmd: [binPath, "-Oz", filePath, "-o", filePath],
     stderr: "inherit",
     stdout: "inherit",
   });
@@ -29,8 +28,6 @@ export async function runWasmOpt(filePath: string) {
   if (!status.success) {
     throw new Error(`error executing wasmopt`);
   }
-
-  await Deno.rename(optimizedPath, filePath);
 }
 
 async function getWasmOptBinaryPath() {


### PR DESCRIPTION
Minor fix:

**Expected**

```
Generating lib JS bindings...
  deno fmt --quiet --ext js -
  write lib\wasmbuild.generated.js
Optimizing .wasm file...
```

**Previous Actual**

```
Generating lib JS bindings...
  deno fmt --quiet --ext js -
Optimizing .wasm file...
  write lib\wasmbuild.generated.js
```