### PR TITLE
fix: do not conflict with a `transform` export

### DIFF
--- a/lib/pre_build.ts
+++ b/lib/pre_build.ts
@@ -312,7 +312,7 @@ export function instantiateWithInstance(transform) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
         instanceWithExports = {
           instance,
-          exports: { ${exportNames.join(", ")} },
+          exports: getWasmInstanceExports(),
         };
         return instanceWithExports;
       } finally {
@@ -321,6 +321,10 @@ export function instantiateWithInstance(transform) {
     })();
   }
   return lastLoadPromise;
+}
+
+function getWasmInstanceExports() {
+  return { ${exportNames.join(", ")} };
 }
 
 /** Gets if the Wasm module has been instantiated. */

--- a/lib/wasmbuild.generated.js
+++ b/lib/wasmbuild.generated.js
@@ -202,7 +202,7 @@ export function instantiateWithInstance(transform) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
         instanceWithExports = {
           instance,
-          exports: { generate_bindgen },
+          exports: getWasmInstanceExports(),
         };
         return instanceWithExports;
       } finally {
@@ -211,6 +211,10 @@ export function instantiateWithInstance(transform) {
     })();
   }
   return lastLoadPromise;
+}
+
+function getWasmInstanceExports() {
+  return { generate_bindgen };
 }
 
 /** Gets if the Wasm module has been instantiated. */

--- a/tests/lib/deno_test.generated.js
+++ b/tests/lib/deno_test.generated.js
@@ -153,7 +153,7 @@ export function instantiateWithInstance(transform) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
         instanceWithExports = {
           instance,
-          exports: { greet },
+          exports: getWasmInstanceExports(),
         };
         return instanceWithExports;
       } finally {
@@ -162,6 +162,10 @@ export function instantiateWithInstance(transform) {
     })();
   }
   return lastLoadPromise;
+}
+
+function getWasmInstanceExports() {
+  return { greet };
 }
 
 /** Gets if the Wasm module has been instantiated. */


### PR DESCRIPTION
I had a `transform` function in dnt and the new param was conflicting with it.