### PR TITLE
fix: use absolute Deno bin path as possible

### DIFF
--- a/lib/pre_build.ts
+++ b/lib/pre_build.ts
@@ -143,7 +143,7 @@ ${genText}
 
   async function getFormattedText(inputText: string) {
     const denoFmtCmdArgs = [
-      "deno",
+      Deno.execPath(),
       "fmt",
       "--quiet",
       "--ext",


### PR DESCRIPTION
In some special environments, for example, Netlify CI, `deno` won't exist in `$PATH` by default. This PR fixes this problem to avoid crash.