### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ Bindings will be generated at `./lib/<crate-name>.generated.js`. Import the
 `instantiate` function and call it asynchronously to get the exports:
 
 ```ts
-import { instantiate } from "./lib/deno_test.generated.js";
+import { instantiate } from "./lib/rs_lib.generated.js";
 
-const { greet } = await instantiate();
-greet("Deno");
+const { add } = await instantiate();
+add(1, 1);
 ```
 
 Or instantiate and use the exports:
 
 ```ts
-import { greet, instantiate } from "./lib/deno_test.generated.js";
+import { add, instantiate } from "./lib/rs_lib.generated.js";
 
 await instantiate();
-greet("Deno");
+add(1, 1);
 ```
 
 ### Compression
@@ -54,7 +54,7 @@ greet("Deno");
 When instantiating, you might want to decompress Wasm bytes.
 
 ```ts
-import { instantiate } from "./lib/deno_test.generated.js";
+import { instantiate } from "./lib/rs_lib.generated.js";
 import { decompress } from "https://deno.land/x/lz4@v0.1.2/mod.ts";
 
 await instantiate({
@@ -69,10 +69,10 @@ Note, however, wasmbuild CLI does not compress the Wasm file automatically.
 A custom URL to the .wasm file may be provided by specifying the `url` option:
 
 ```ts
-import { instantiate } from "./lib/deno_test.generated.js";
+import { instantiate } from "./lib/rs_lib.generated.js";
 
 await instantiate({
-  url: new URL("./custom_path_to_url.wasm", import.meta),
+  url: new URL("./custom_path_to_url.wasm", import.meta.url),
 });
 ```
 


### PR DESCRIPTION
When following the README from top to bottom, its weird that instructions use `test.js` where the scaffold has created `rs_lib...js` (with add function), I think this is more intuitive and less hassle to anyone following the README for the first time

Also changed one `import.meta` to `import.meta.url` I think that's correct