### PR TITLE
fix: download the correct `wasm-opt` binary for Apple silicon Macs

### DIFF
--- a/lib/wasmopt.ts
+++ b/lib/wasmopt.ts
@@ -102,12 +102,16 @@ async function downloadBinaryen(tempPath: string) {
 }
 
 function binaryenUrl() {
-  const target = {
-    "linux": "x86_64-linux",
-    "darwin": "x86_64-macos",
-    "windows": "x86_64-windows",
+  const os = {
+    "linux": "linux",
+    "darwin": "macos",
+    "windows": "windows",
   }[Deno.build.os];
+  const arch = {
+    "x86_64": "x86_64",
+    "aarch64": "arm64",
+  }[Deno.build.arch];
   return new URL(
-    `https://github.com/WebAssembly/binaryen/releases/download/${tag}/binaryen-${tag}-${target}.tar.gz`,
+    `https://github.com/WebAssembly/binaryen/releases/download/${tag}/binaryen-${tag}-${arch}-${os}.tar.gz`,
   );
 }


### PR DESCRIPTION
Fixes #59 by downloading the right `wasm-opt` binary for Apple silicon Macs:

- #59

Now `binaryenUrl()` function checks the CPU architecture using `Deno.build.arch` ([doc](https://deno.land/api@v1.28.1?s=Deno.build)). If it is `aarch64`, it will generate a URL ending with `binaryen-${tag}-arm64-macos.tar.gz` instead of `binaryen-${tag}-x86_64-macos.tar.gz`