### PR TITLE
chore: update rust to 1.69.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.69.0"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
fix https://github.com/denoland/wasmbuild/issues/82