### PR TITLE
docs: add a console.log to the js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Bindings will be generated at `./lib/<crate-name>.generated.js`. Import the
 import { instantiate } from "./lib/rs_lib.generated.js";
 
 const { add } = await instantiate();
-add(1, 1);
+console.log(add(1, 1));
 ```
 
 Or instantiate and use the exports:
@@ -46,7 +46,7 @@ Or instantiate and use the exports:
 import { add, instantiate } from "./lib/rs_lib.generated.js";
 
 await instantiate();
-add(1, 1);
+console.log(add(1, 1));
 ```
 
 ### Compression


### PR DESCRIPTION
Its a small thing , but when I first copied the code and run it  I left wondering for a sec why there is no output and if its working, so this just makes life easier

Also what about generating a main.ts (with deno task wasmbuild new) that have the example ?