### PR TITLE
fix: correct cargo warnings

### DIFF
--- a/lib/commands/new_command.ts
+++ b/lib/commands/new_command.ts
@@ -25,7 +25,12 @@ export async function runNewCommand() {
 members = [
   "rs_lib",
 ]
-edition = "2021"
+
+[profile.release]
+codegen-units = 1
+incremental = true
+lto = true
+opt-level = "z"
 `,
     );
   }
@@ -59,12 +64,6 @@ edition = "2021"
 
 [lib]
 crate_type = ["cdylib"]
-
-[profile.release]
-codegen-units = 1
-incremental = true
-lto = true
-opt-level = "z"
 
 [dependencies]
 wasm-bindgen = "=${versions.wasmBindgen}"


### PR DESCRIPTION
- profile should be on the workspace toml file
- edition key doesn't exist in the worksapce toml, its need to be set on each crate toml