### PR TITLE
feat: improve scaffold

### DIFF
--- a/lib/commands/new_command.ts
+++ b/lib/commands/new_command.ts
@@ -77,6 +77,23 @@ wasm-bindgen = "=${versions.wasmBindgen}"
     `use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+pub struct Greeter {
+  name: String,
+}
+
+#[wasm_bindgen]
+impl Greeter {
+  #[wasm_bindgen(constructor)]
+  pub fn new(name: String) -> Self {
+    Self { name }
+  }
+
+  pub fn greet(&self) -> String {
+    format!("hello {}!", self.name)
+  }
+}
+
+#[wasm_bindgen]
 pub fn add(a: i32, b: i32) -> i32 {
   return a + b;
 }
@@ -87,6 +104,8 @@ mod tests {
 
   #[test]
   fn it_works() {
+    let greeter = Greeter::new("world".into());
+    assert_eq!(greeter.greet(), "hello world!");
     let result = add(1, 2);
     assert_eq!(result, 3);
   }
@@ -98,8 +117,11 @@ mod tests {
       "./mod.ts",
       `import { instantiate } from "./lib/rs_lib.generated.js";
 
-const { add } = await instantiate();
+const { Greeter, add } = await instantiate();
+
 console.log(add(1, 1));
+const greeter = new Greeter("world");
+console.log(greeter.greet());
 `,
     );
   }


### PR DESCRIPTION
I think its nice to showcase more useful thing you can export

I guess the only major functionality of wasm-bindgen that is not currently is showcased is the ability to use js functions in rust like
```rs
#[wasm_bindgen]
extern "C" {
  fn hello() -> String;
  #[wasm_bindgen(js_namespace = Deno)]
  fn cwd() -> String;
  #[wasm_bindgen(js_namespace = console)]
  fn log(s: &str);
}
```
maybe its worth to add  as well? 