### PR TITLE
chore: bump `jsr:@david/publish-on-tag` to 0.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Publish on tag
         if: contains(matrix.os, 'ubuntu')
-        run: deno run -A jsr:@david/publish-on-tag@0.1.2 --allow-dirty
+        run: deno run -A jsr:@david/publish-on-tag@0.1.3 --allow-dirty


### PR DESCRIPTION
There was a bug where it wasn't surfacing the exit code when running `deno publish`.