### PR TITLE
fix: ensure `__wbindgen_start` is called when necessary for `--inline`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,7 @@
     "fmt": "deno fmt && cargo fmt",
     "build": "WASMBUILD_BINDGEN_UPGRADE=1 deno run -A ./main.ts -p wasmbuild",
     "build:lkg": "deno run -A jsr:@deno/wasmbuild@^0.15.4 -p wasmbuild",
-    "test": "cd tests && rm -rf lib lib_out_js_file lib_inline lib_no_cache && deno task test:main && deno task test:js-ext && deno task test:inline && deno test -A && deno task test:check && deno task test:start && deno task test::start-inline",
+    "test": "cd tests && rm -rf lib lib_out_js_file lib_inline lib_no_cache && deno task test:main && deno task test:js-ext && deno task test:inline && deno test -A && deno task test:check && deno task test:start && deno task test:start-inline",
     "test:main": "cd tests && deno run -A ../main.ts -p deno_test",
     "test:js-ext": "deno task test:main --js-ext mjs --out lib_out_js_file && cat tests/lib_out_js_file/deno_test.mjs > /dev/null",
     "test:check": "deno task test:main --check",

--- a/deno.json
+++ b/deno.json
@@ -21,12 +21,13 @@
     "fmt": "deno fmt && cargo fmt",
     "build": "WASMBUILD_BINDGEN_UPGRADE=1 deno run -A ./main.ts -p wasmbuild",
     "build:lkg": "deno run -A jsr:@deno/wasmbuild@^0.15.4 -p wasmbuild",
-    "test": "cd tests && rm -rf lib lib_out_js_file lib_inline lib_no_cache && deno task test:main && deno task test:js-ext && deno task test:inline && deno test -A && deno task test:check && deno task test:start",
+    "test": "cd tests && rm -rf lib lib_out_js_file lib_inline lib_no_cache && deno task test:main && deno task test:js-ext && deno task test:inline && deno test -A && deno task test:check && deno task test:start && deno task test::start-inline",
     "test:main": "cd tests && deno run -A ../main.ts -p deno_test",
     "test:js-ext": "deno task test:main --js-ext mjs --out lib_out_js_file && cat tests/lib_out_js_file/deno_test.mjs > /dev/null",
     "test:check": "deno task test:main --check",
     "test:inline": "deno task test:main --inline --out lib_inline",
-    "test:start": "cd tests && deno run -A ../main.ts -p deno_test --features start && USES_START=1 deno test -A test.ts"
+    "test:start": "cd tests && deno run -A ../main.ts -p deno_test --features start && USES_START=1 deno test -A test.ts",
+    "test:start-inline": "cd tests && deno run -A ../main.ts -p deno_test --features start --inline && USES_START=1 deno test -A test.ts"
   },
   "imports": {
     "@david/path": "jsr:@david/path@^0.2.0",

--- a/lib/commands/build_command.ts
+++ b/lib/commands/build_command.ts
@@ -130,7 +130,7 @@ const wasm = new WebAssembly.Instance(wasmModule, {
 
 export * from "./${output.bindingJsBg.path.basename()}";
 import { __wbg_set_wasm } from "./${output.bindingJsBg.path.basename()}";
-__wbg_set_wasm(wasm.exports);
+__wbg_set_wasm(wasm.exports);${output.hasStart ? "\nwasm.exports.__wbindgen_start();" : ""}
 
 function base64decode(b64) {
   const binString = atob(b64);

--- a/lib/commands/build_command.ts
+++ b/lib/commands/build_command.ts
@@ -130,7 +130,9 @@ const wasm = new WebAssembly.Instance(wasmModule, {
 
 export * from "./${output.bindingJsBg.path.basename()}";
 import { __wbg_set_wasm } from "./${output.bindingJsBg.path.basename()}";
-__wbg_set_wasm(wasm.exports);${output.hasStart ? "\nwasm.exports.__wbindgen_start();" : ""}
+__wbg_set_wasm(wasm.exports);${
+      output.hasStart ? "\nwasm.exports.__wbindgen_start();" : ""
+    }
 
 function base64decode(b64) {
   const binString = atob(b64);


### PR DESCRIPTION
Closes https://github.com/denoland/wasmbuild/issues/156