### PR TITLE
feat: improve setup and new command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # exclude these from the language stats
-lib/wasmbuild_bg.js linguist-vendored
+lib/wasmbuild.js linguist-vendored

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ deno run -A jsr:@deno/wasmbuild new
 This also adds a `wasmbuild` task to the _deno.json_ file and installs
 `@deno/wasmbuild`.
 
-## Or manual setup
+## Manual setup
 
 1. `deno install jsr:@deno/wasmbuild`
 1. Update _deno.json_ with:

--- a/README.md
+++ b/README.md
@@ -2,17 +2,29 @@
 
 A build tool to generate wasm-bindgen glue code for Deno and the browser.
 
-## Setup
+## Scaffold project
 
-Add a task to the _deno.json_ file in your project:
+To create a starter Rust crate in an `rs_lib` subfolder of your project, run:
 
-```json
-{
-  "tasks": {
-    "wasmbuild": "deno run -A jsr:@deno/wasmbuild@VERSION_GOES_HERE"
-  }
-}
+```bash
+deno run -A jsr:@deno/wasmbuild new
 ```
+
+This also adds a `wasmbuild` task to the _deno.json_ file and installs
+`@deno/wasmbuild`.
+
+## Or manual setup
+
+1. `deno install jsr:@deno/wasmbuild`
+1. Update _deno.json_ with:
+
+   ```json
+   {
+     "tasks": {
+       "wasmbuild": "deno run -A @deno/wasmbuild"
+     }
+   }
+   ```
 
 ## Browser, Node.js, or older Deno support
 
@@ -21,14 +33,6 @@ a bug unfortunately).
 
 Most browsers do not support Wasm imports yet, which this library generates. If
 you want output that works in more scenarios, build with the `--inline` flag.
-
-## Scaffold project (Optional)
-
-To create a starter Rust crate in an `rs_lib` subfolder of your project, run:
-
-```bash
-deno task wasmbuild new
-```
 
 ## Building
 

--- a/deno.json
+++ b/deno.json
@@ -30,6 +30,7 @@
     "test:start-inline": "cd tests && deno run -A ../main.ts -p deno_test --features start --inline && USES_START=1 deno test -A test.ts"
   },
   "imports": {
+    "@david/jsonc-morph": "jsr:@david/jsonc-morph@^0.3.4",
     "@david/path": "jsr:@david/path@^0.2.0",
     "@david/temp": "jsr:@david/temp@^0.1.1",
     "@std/assert": "jsr:@std/assert@^1.0.11",

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
+    "jsr:@david/jsonc-morph@~0.3.4": "0.3.4",
     "jsr:@david/path@0.2": "0.2.0",
     "jsr:@david/temp@~0.1.1": "0.1.1",
     "jsr:@std/assert@^1.0.11": "1.0.11",
@@ -17,6 +18,9 @@
     "jsr:@std/tar@~0.1.4": "0.1.4"
   },
   "jsr": {
+    "@david/jsonc-morph@0.3.4": {
+      "integrity": "a4af7c80b3c233d3856da1e9f2009d251867bee351fea016b22b67d6291c3455"
+    },
     "@david/path@0.2.0": {
       "integrity": "f2d7aa7f02ce5a55e27c09f9f1381794acb09d328f8d3c8a2e3ab3ffc294dccd",
       "dependencies": [
@@ -75,6 +79,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@david/jsonc-morph@~0.3.4",
       "jsr:@david/path@0.2",
       "jsr:@david/temp@~0.1.1",
       "jsr:@std/assert@^1.0.11",

--- a/lib/commands/new_command.ts
+++ b/lib/commands/new_command.ts
@@ -1,8 +1,11 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 import * as colors from "@std/fmt/colors";
+import * as jsonc from "@david/jsonc-morph";
 import { versions } from "../versions.ts";
 import { Path } from "@david/path";
+
+const WASMBUILD_TASK = "deno run -A @deno/wasmbuild";
 
 export async function runNewCommand() {
   await checkIfRequiredToolsExist();
@@ -132,9 +135,60 @@ console.log(greeter.greet());
 `,
   );
 
+  ensureWasmbuildTask(rootDir);
+  await installWasmbuild(rootDir);
+
   console.log("%cTo get started run:", "color:yellow");
   console.log("deno task wasmbuild");
   console.log("deno run mod.js");
+}
+
+/**
+ * Adds the wasmbuild task to the Deno config file, creating a
+ * deno.json when one doesn't exist.
+ */
+function ensureWasmbuildTask(rootDir: Path) {
+  const configFile = getDenoConfigFile(rootDir);
+  const configText = configFile.readMaybeTextSync();
+  using root = jsonc.parse(configText ?? "");
+  const tasks = root.asObjectOrForce().getIfObjectOrForce("tasks");
+  if (tasks.get("wasmbuild") != null) {
+    return;
+  }
+
+  console.log(
+    `${
+      colors.bold(colors.green(configText == null ? "Creating" : "Updating"))
+    } ${configFile.basename()}...`,
+  );
+  tasks.ensureMultiline();
+  tasks.append("wasmbuild", WASMBUILD_TASK);
+  configFile.writeTextSync(root.toString());
+}
+
+/** Deno resolves a deno.json file before a deno.jsonc file. */
+function getDenoConfigFile(rootDir: Path) {
+  const jsonFile = rootDir.join("deno.json");
+  if (jsonFile.existsSync()) {
+    return jsonFile;
+  }
+  const jsoncFile = rootDir.join("deno.jsonc");
+  return jsoncFile.existsSync() ? jsoncFile : jsonFile;
+}
+
+async function installWasmbuild(rootDir: Path) {
+  console.log(
+    `${colors.bold(colors.green("Installing"))} @deno/wasmbuild...`,
+  );
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["install", "jsr:@deno/wasmbuild"],
+    cwd: rootDir.toString(),
+  })
+    .spawn()
+    .status;
+  if (!output.success) {
+    throw new Error("Failed installing @deno/wasmbuild.");
+  }
 }
 
 function writeIfNotExists(path: Path, text: string) {

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -1,19 +1,38 @@
-import { createTempDirSync } from "@david/temp";
+import { createTempDirSync, type TempDir } from "@david/temp";
 import { Path } from "@david/path";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "@std/assert";
 
 const rootFolder = new Path(import.meta.dirname!).parentOrThrow();
+const mainTsPath = rootFolder.join("main.ts").toString();
+const wasmbuildTask = "deno run -A @deno/wasmbuild";
+
+interface DenoConfig {
+  tasks?: Record<string, string>;
+  imports?: Record<string, string>;
+  [key: string]: unknown;
+}
 
 Deno.test("should create a new wasmbuild project, build it, and run it", async () => {
   using tempDir = createTempDirSync();
-  tempDir.join("deno.json").writeTextSync(
-    `{ "tasks": { "wasmbuild": "${
-      Deno.execPath().replace(/\\/g, "\\\\")
-    } run -A ${
-      rootFolder.join("main.ts").toString().replace(/\\/g, "\\\\")
-    }" }}\n`,
-  );
-  await runCommand("deno", "task", "wasmbuild", "new");
-  await runCommand("deno", "task", "wasmbuild");
+  await runNewCommand(tempDir);
+
+  const configFile = tempDir.join("deno.json");
+  const config = configFile.readJsonSync<DenoConfig>();
+  assertEquals(config.tasks?.wasmbuild, wasmbuildTask);
+  assertMatch(config.imports!["@deno/wasmbuild"], /^jsr:@deno\/wasmbuild@/);
+  // the created task and import should work together
+  await runCommand(tempDir, "deno", "task", "wasmbuild", "--help");
+
+  // now build using this repo's code instead of the published version
+  config.tasks!.wasmbuild = `${Deno.execPath()} run -A ${mainTsPath}`;
+  configFile.writeJsonPrettySync(config);
+
+  await runCommand(tempDir, "deno", "task", "wasmbuild");
   tempDir.join("test.ts").writeTextSync(`
 import { add } from "./lib/rs_lib.js";
 
@@ -24,17 +43,140 @@ Deno.test("should add values", async () => {
   }
 });
 `);
-  await runCommand("deno", "test", "-A");
-  await runCommand("cargo", "test");
-
-  async function runCommand(cmd: string, ...args: string[]) {
-    const p = new Deno.Command(cmd, {
-      args,
-      cwd: tempDir.toString(),
-    }).spawn();
-    const output = await p.status;
-    if (!output.success) {
-      throw new Error("FAILED");
-    }
-  }
+  await runCommand(tempDir, "deno", "test", "-A");
+  await runCommand(tempDir, "cargo", "test");
 });
+
+Deno.test("should fill in an existing deno.json", async () => {
+  using tempDir = createTempDirSync();
+  const configFile = tempDir.join("deno.json");
+  configFile.writeTextSync(`{
+  "name": "@scope/name",
+  "exports": "./mod.js",
+  "tasks": {
+    "other": "echo 1"
+  }
+}
+`);
+
+  await runNewCommand(tempDir);
+
+  const config = configFile.readJsonSync<DenoConfig>();
+  assertEquals(config.name, "@scope/name");
+  assertEquals(config.exports, "./mod.js");
+  assertEquals(config.tasks, {
+    other: "echo 1",
+    wasmbuild: wasmbuildTask,
+  });
+  assertMatch(config.imports!["@deno/wasmbuild"], /^jsr:@deno\/wasmbuild@/);
+});
+
+Deno.test("should keep an existing wasmbuild task in the deno.json", async () => {
+  using tempDir = createTempDirSync();
+  const configFile = tempDir.join("deno.json");
+  configFile.writeTextSync(
+    `{\n  "tasks": {\n    "wasmbuild": "deno run -A ./main.ts"\n  }\n}\n`,
+  );
+
+  await runNewCommand(tempDir);
+
+  const config = configFile.readJsonSync<DenoConfig>();
+  assertEquals(config.tasks?.wasmbuild, "deno run -A ./main.ts");
+  assertMatch(config.imports!["@deno/wasmbuild"], /^jsr:@deno\/wasmbuild@/);
+});
+
+Deno.test("should fill in a deno.jsonc keeping the comments", async () => {
+  using tempDir = createTempDirSync();
+  const configFile = tempDir.join("deno.jsonc");
+  configFile.writeTextSync(`{\n  // a comment\n  "tasks": {}\n}\n`);
+
+  await runNewCommand(tempDir);
+
+  assert(!tempDir.join("deno.json").existsSync());
+  const configText = configFile.readTextSync();
+  assertStringIncludes(
+    configText,
+    `  // a comment\n  "tasks": {\n    "wasmbuild": "${wasmbuildTask}"\n  },\n`,
+  );
+  assertMatch(configText, /"@deno\/wasmbuild": "jsr:@deno\/wasmbuild@/);
+});
+
+Deno.test("should keep the comments in a deno.json with comments", async () => {
+  using tempDir = createTempDirSync();
+  const configFile = tempDir.join("deno.json");
+  configFile.writeTextSync(`{\n  // a comment\n  "tasks": {}\n}\n`);
+
+  await runNewCommand(tempDir);
+
+  const configText = configFile.readTextSync();
+  assertStringIncludes(
+    configText,
+    `  // a comment\n  "tasks": {\n    "wasmbuild": "${wasmbuildTask}"\n  },\n`,
+  );
+  assertMatch(configText, /"@deno\/wasmbuild": "jsr:@deno\/wasmbuild@/);
+});
+
+Deno.test("should prefer the deno.json over the deno.jsonc", async () => {
+  using tempDir = createTempDirSync();
+  const jsoncFile = tempDir.join("deno.jsonc");
+  jsoncFile.writeTextSync(`{\n  // a comment\n  "tasks": {}\n}\n`);
+  const configFile = tempDir.join("deno.json");
+  configFile.writeTextSync(`{}\n`);
+
+  await runNewCommand(tempDir);
+
+  assertEquals(configFile.readJsonSync<DenoConfig>().tasks, {
+    wasmbuild: wasmbuildTask,
+  });
+  assertEquals(
+    jsoncFile.readTextSync(),
+    `{\n  // a comment\n  "tasks": {}\n}\n`,
+  );
+});
+
+Deno.test("should fill in an empty deno.json", async () => {
+  using tempDir = createTempDirSync();
+  const configFile = tempDir.join("deno.json");
+  configFile.writeTextSync("");
+
+  await runNewCommand(tempDir);
+
+  assertEquals(configFile.readJsonSync<DenoConfig>().tasks, {
+    wasmbuild: wasmbuildTask,
+  });
+});
+
+Deno.test("should keep an existing wasmbuild task in the deno.jsonc", async () => {
+  using tempDir = createTempDirSync();
+  const configFile = tempDir.join("deno.jsonc");
+  configFile.writeTextSync(
+    `{\n  // a comment\n  "tasks": {\n    "wasmbuild": "deno run -A ./main.ts"\n  }\n}\n`,
+  );
+
+  await runNewCommand(tempDir);
+
+  const configText = configFile.readTextSync();
+  assertStringIncludes(
+    configText,
+    `  // a comment\n  "tasks": {\n    "wasmbuild": "deno run -A ./main.ts"\n  },\n`,
+  );
+});
+
+function runNewCommand(cwd: TempDir) {
+  return runCommand(cwd, Deno.execPath(), "run", "-A", mainTsPath, "new");
+}
+
+async function runCommand(cwd: TempDir, cmd: string, ...args: string[]) {
+  const output = await new Deno.Command(cmd, {
+    args,
+    cwd: cwd.toString(),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const text = new TextDecoder().decode(output.stdout) +
+    new TextDecoder().decode(output.stderr);
+  if (!output.success) {
+    throw new Error(`FAILED\n${text}`);
+  }
+  return text;
+}


### PR DESCRIPTION
Running `deno run -A jsr:@deno/wasmbuild new` now gets a project all the way to a
  working state instead of leaving the _deno.json_ setup to the reader.

  On top of scaffolding the `rs_lib` crate, the `new` command now:

  1. Adds a `wasmbuild` task to the _deno.json_ file—the same task the manual setup
     instructions describe (`"wasmbuild": "deno run -A @deno/wasmbuild"`), creating
     the file when it doesn't exist and filling in only what's missing when it does.
  2. Runs `deno install jsr:@deno/wasmbuild` in the folder.

  The config file is edited with [`@david/jsonc-morph`](https://jsr.io/@david/jsonc-morph),
  so comments, key order, and existing formatting all survive—a _deno.jsonc_ file
  (or a _deno.json_ with comments, which Deno also accepts) gets filled in like any
  other config. A _deno.json_ takes precedence over a _deno.jsonc_ when both exist,
  matching Deno's own resolution, and an existing `wasmbuild` task is never
  overwritten.

  The README is restructured to lead with the scaffold command and keep the manual
  setup as the alternative.